### PR TITLE
Fix inspector docstring

### DIFF
--- a/stix2patterns/inspector.py
+++ b/stix2patterns/inspector.py
@@ -162,12 +162,11 @@ class InspectionListener(STIXPatternListener):
 
 def get_parse_tree(pattern):
     """
-    Match the given pattern against the given observations.  Returns matching
-    SDOs.  The matcher can find many bindings; this function returns the SDOs
-    corresponding to only the first binding found.
+    Parses the given pattern and returns the antlr parse tree.
 
     :param pattern: The STIX pattern
     :return: The parse tree
+    :raises ParseException: If there is a parse error
     """
 
     in_ = antlr4.InputStream(pattern)
@@ -227,7 +226,8 @@ def get_parse_tree(pattern):
 
 
 def inspect_pattern(pattern):
-    """Inspect a pattern and pull "stuff" out of it.  The details are TBD."""
+    """Inspect a pattern and extract information from it.  The details are TBD.
+    """
 
     tree = get_parse_tree(pattern)
 

--- a/stix2patterns/test/test_inspector.py
+++ b/stix2patterns/test/test_inspector.py
@@ -34,7 +34,7 @@ def test_qualifiers(pattern, expected_qualifiers):
     (u"[foo:bar = 1] or ([foo:baz = false] followedby [frob:abc like '123']) within 46.1 seconds",
         set([u"OR", u"FOLLOWEDBY"]))
 ])
-def test_observation_opts(pattern, expected_obs_ops):
+def test_observation_ops(pattern, expected_obs_ops):
     pattern_data = inspect_pattern(pattern)
 
     assert pattern_data.observation_ops == expected_obs_ops


### PR DESCRIPTION
After seeing the recent pattern matcher issue and looking at the inspector again, the docstring on get_parse_tree() jumped out at me.  I pasted in code from the matcher but apparently forgot to change the docstring, so it was completely wrong.  So I fixed it.

Also slipped in a typo correction in the tests.