### PR TITLE
Precompiled patterns

### DIFF
--- a/stix2patterns/pattern.py
+++ b/stix2patterns/pattern.py
@@ -1,0 +1,101 @@
+import antlr4
+import antlr4.error.ErrorListener
+import six
+
+import stix2patterns.inspector
+from stix2patterns.grammars.STIXPatternLexer import STIXPatternLexer
+from stix2patterns.grammars.STIXPatternParser import STIXPatternParser
+
+
+class MatcherErrorListener(antlr4.error.ErrorListener.ErrorListener):
+    """
+    Simple error listener which just remembers the last error message received.
+    """
+    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
+        self.error_message = u"{}:{}: {}".format(line, column, msg)
+
+
+class ParseException(Exception):
+    """Represents a parse error."""
+    pass
+
+
+class Pattern(object):
+    """
+    Represents a pattern in a "compiled" form, for more efficient reuse.
+    """
+    def __init__(self, pattern_str):
+        self.__parse_tree = self.__do_parse(pattern_str)
+
+    def inspect(self):
+
+        inspector = stix2patterns.inspector.InspectionListener()
+        antlr4.ParseTreeWalker.DEFAULT.walk(inspector, self.__parse_tree)
+
+        return inspector.pattern_data()
+
+    def get_parse_tree(self):
+        return self.__parse_tree
+
+    def __do_parse(self, pattern_str):
+        """
+        Parses the given pattern and returns the antlr parse tree.
+
+        :param pattern_str: The STIX pattern
+        :return: The parse tree
+        :raises ParseException: If there is a parse error
+        """
+        in_ = antlr4.InputStream(pattern_str)
+        lexer = STIXPatternLexer(in_)
+        lexer.removeErrorListeners()  # remove the default "console" listener
+        token_stream = antlr4.CommonTokenStream(lexer)
+
+        parser = STIXPatternParser(token_stream)
+        parser.removeErrorListeners()  # remove the default "console" listener
+        error_listener = MatcherErrorListener()
+        parser.addErrorListener(error_listener)
+
+        # I found no public API for this...
+        # The default error handler tries to keep parsing, and I don't
+        # think that's appropriate here.  (These error handlers are only for
+        # handling the built-in RecognitionException errors.)
+        parser._errHandler = antlr4.BailErrorStrategy()
+
+        # To improve error messages, replace "<INVALID>" in the literal
+        # names with symbolic names.  This is a hack, but seemed like
+        # the simplest workaround.
+        for i, lit_name in enumerate(parser.literalNames):
+            if lit_name == u"<INVALID>":
+                parser.literalNames[i] = parser.symbolicNames[i]
+
+        # parser.setTrace(True)
+
+        try:
+            tree = parser.pattern()
+            # print(tree.toStringTree(recog=parser))
+
+            return tree
+        except antlr4.error.Errors.ParseCancellationException as e:
+            # The cancellation exception wraps the real RecognitionException which
+            # caused the parser to bail.
+            real_exc = e.args[0]
+
+            # I want to bail when the first error is hit.  But I also want
+            # a decent error message.  When an error is encountered in
+            # Parser.match(), the BailErrorStrategy produces the
+            # ParseCancellationException.  It is not a subclass of
+            # RecognitionException, so none of the 'except' clauses which would
+            # normally report an error are invoked.
+            #
+            # Error message creation is buried in the ErrorStrategy, and I can
+            # (ab)use the API to get a message: register an error listener with
+            # the parser, force an error report, then get the message out of the
+            # listener.  Error listener registration is above; now we force its
+            # invocation.  Wish this could be cleaner...
+            parser._errHandler.reportError(parser, real_exc)
+
+            # should probably chain exceptions if we can...
+            # Should I report the cancellation or recognition exception as the
+            # cause...?
+            six.raise_from(ParseException(error_listener.error_message),
+                           real_exc)

--- a/stix2patterns/pattern.py
+++ b/stix2patterns/pattern.py
@@ -34,6 +34,12 @@ class Pattern(object):
         self.__parse_tree = self.__do_parse(pattern_str)
 
     def inspect(self):
+        """
+        Inspect a pattern.  This gives information regarding the sorts of
+        operations, content, etc in use in the pattern.
+
+        :return: Pattern information
+        """
 
         inspector = stix2patterns.inspector.InspectionListener()
         antlr4.ParseTreeWalker.DEFAULT.walk(inspector, self.__parse_tree)

--- a/stix2patterns/test/test_inspector.py
+++ b/stix2patterns/test/test_inspector.py
@@ -1,6 +1,6 @@
 import pytest
 
-from stix2patterns.inspector import inspect_pattern
+from stix2patterns.pattern import Pattern
 
 
 @pytest.mark.parametrize(u"pattern,expected_qualifiers", [
@@ -20,7 +20,8 @@ from stix2patterns.inspector import inspect_pattern
             u"WITHIN 22 SECONDS", u"REPEATS 31 TIMES"]))
 ])
 def test_qualifiers(pattern, expected_qualifiers):
-    pattern_data = inspect_pattern(pattern)
+    compiled_pattern = Pattern(pattern)
+    pattern_data = compiled_pattern.inspect()
 
     assert pattern_data.qualifiers == expected_qualifiers
 
@@ -35,7 +36,8 @@ def test_qualifiers(pattern, expected_qualifiers):
         set([u"OR", u"FOLLOWEDBY"]))
 ])
 def test_observation_ops(pattern, expected_obs_ops):
-    pattern_data = inspect_pattern(pattern)
+    compiled_pattern = Pattern(pattern)
+    pattern_data = compiled_pattern.inspect()
 
     assert pattern_data.observation_ops == expected_obs_ops
 
@@ -58,6 +60,7 @@ def test_observation_ops(pattern, expected_obs_ops):
         })
 ])
 def test_comparisons(pattern, expected_comparisons):
-    pattern_data = inspect_pattern(pattern)
+    compiled_pattern = Pattern(pattern)
+    pattern_data = compiled_pattern.inspect()
 
     assert pattern_data.comparisons == expected_comparisons


### PR DESCRIPTION
This PR introduces a Pattern class which encapsulates a pattern parse tree.  This allows reuse of the pattern without needing to keep reparsing it.  Pattern inspection is now done via the inspect() method of this class.