### PR TITLE
Changed inspector to split up object paths into lists

### DIFF
--- a/stix2patterns/test/test_inspector.py
+++ b/stix2patterns/test/test_inspector.py
@@ -1,6 +1,7 @@
 import pytest
 
 from stix2patterns.pattern import Pattern
+from stix2patterns.inspector import INDEX_STAR
 
 
 @pytest.mark.parametrize(u"pattern,expected_qualifiers", [
@@ -43,21 +44,24 @@ def test_observation_ops(pattern, expected_obs_ops):
 
 
 @pytest.mark.parametrize(u"pattern,expected_comparisons", [
-    (u"[foo:bar = 1]", {u"foo": [(u"bar", u"=", u"1")]}),
-    (u"[foo:bar=1 and foo:baz=2]", {u"foo": [(u"bar", u"=", u"1"), (u"baz", u"=", u"2")]}),
+    (u"[foo:bar = 1]", {u"foo": [([u"bar"], u"=", u"1")]}),
+    (u"[foo:bar=1 and foo:baz=2]", {u"foo": [([u"bar"], u"=", u"1"), ([u"baz"], u"=", u"2")]}),
     (u"[foo:bar=1 or bar:foo<12.3]", {
-        u"foo": [(u"bar", u"=", u"1")],
-        u"bar": [(u"foo", u"<", u"12.3")]
+        u"foo": [([u"bar"], u"=", u"1")],
+        u"bar": [([u"foo"], u"<", u"12.3")]
     }),
     (u"[foo:bar=1] or [foo:baz matches '123\\\\d+']", {
-        u"foo": [(u"bar", u"=", u"1"), (u"baz", u"MATCHES", u"'123\\\\d+'")]
+        u"foo": [([u"bar"], u"=", u"1"), ([u"baz"], u"MATCHES", u"'123\\\\d+'")]
     }),
     (u"[foo:bar=1 and bar:foo>33] repeats 12 times or "
      u"  ([baz:bar issubset '1234'] followedby [baz:quux not like 'a_cd'])", {
-        u"foo": [(u"bar", u"=", u"1")],
-        u"bar": [(u"foo", u">", u"33")],
-        u"baz": [(u"bar", u"ISSUBSET", u"'1234'"), (u"quux", u"NOT LIKE", u"'a_cd'")]
-        })
+        u"foo": [([u"bar"], u"=", u"1")],
+        u"bar": [([u"foo"], u">", u"33")],
+        u"baz": [([u"bar"], u"ISSUBSET", u"'1234'"), ([u"quux"], u"NOT LIKE", u"'a_cd'")]
+        }),
+    (u"[obj-type:a.b[*][1].'c-d' not issuperset '1.2.3.4/16']", {
+        u"obj-type": [([u"a", u"b", INDEX_STAR, 1, u"c-d"], u"NOT ISSUPERSET", u"'1.2.3.4/16'")]
+    }),
 ])
 def test_comparisons(pattern, expected_comparisons):
     compiled_pattern = Pattern(pattern)


### PR DESCRIPTION
Object paths are now split into lists of strings (for properties), ints, (for array indices), and the special INDEX_STAR value for array "star" indices.  Modified existing tests so they'll pass again, and added one additional test to exercise the splitting and different types of path components.