### PR TITLE
Add support for the 'NOT' qualifier before equality and order operators.

### DIFF
--- a/stix2patterns/grammars/STIXPatternParser.py
+++ b/stix2patterns/grammars/STIXPatternParser.py
@@ -8,7 +8,7 @@ import sys
 def serializedATN():
     with StringIO() as buf:
         buf.write(u"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3")
-        buf.write(u"\64\u00e2\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7")
+        buf.write(u"\64\u00e8\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7")
         buf.write(u"\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t\13\4\f\t\f\4\r\t")
         buf.write(u"\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22")
         buf.write(u"\4\23\t\23\3\2\3\2\3\3\3\3\3\3\3\3\3\3\3\3\7\3/\n\3\f")
@@ -17,90 +17,93 @@ def serializedATN():
         buf.write(u"H\13\5\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\5\6S\n\6\3")
         buf.write(u"\6\3\6\3\6\3\6\3\6\3\6\7\6[\n\6\f\6\16\6^\13\6\3\7\3")
         buf.write(u"\7\3\7\3\7\3\7\3\7\7\7f\n\7\f\7\16\7i\13\7\3\b\3\b\3")
-        buf.write(u"\b\3\b\3\b\3\b\7\bq\n\b\f\b\16\bt\13\b\3\t\3\t\3\t\3")
-        buf.write(u"\t\3\t\3\t\3\t\3\t\3\t\3\t\5\t\u0080\n\t\3\t\3\t\3\t")
-        buf.write(u"\3\t\3\t\5\t\u0087\n\t\3\t\3\t\3\t\3\t\3\t\5\t\u008e")
-        buf.write(u"\n\t\3\t\3\t\3\t\3\t\3\t\5\t\u0095\n\t\3\t\3\t\3\t\3")
-        buf.write(u"\t\3\t\5\t\u009c\n\t\3\t\3\t\3\t\3\t\3\t\3\t\3\t\5\t")
-        buf.write(u"\u00a5\n\t\3\n\3\n\3\n\3\n\3\n\3\13\3\13\3\13\3\13\3")
-        buf.write(u"\f\3\f\3\f\3\f\3\r\3\r\3\r\3\r\5\r\u00b8\n\r\3\16\3\16")
-        buf.write(u"\3\17\3\17\3\20\3\20\3\20\3\20\3\20\3\20\5\20\u00c4\n")
-        buf.write(u"\20\3\20\3\20\7\20\u00c8\n\20\f\20\16\20\u00cb\13\20")
-        buf.write(u"\3\21\3\21\3\21\3\21\3\21\3\21\7\21\u00d3\n\21\f\21\16")
-        buf.write(u"\21\u00d6\13\21\3\21\3\21\5\21\u00da\n\21\3\22\3\22\5")
-        buf.write(u"\22\u00de\n\22\3\23\3\23\3\23\2\t\4\6\b\n\f\16\36\24")
-        buf.write(u"\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$\2\t\3\2\36")
-        buf.write(u"\37\3\2 #\3\2\3\4\3\2\34\35\4\2\7\7\34\34\4\2\3\3\61")
-        buf.write(u"\61\4\2\3\7\t\t\2\u00ea\2&\3\2\2\2\4(\3\2\2\2\6\63\3")
-        buf.write(u"\2\2\2\b>\3\2\2\2\nR\3\2\2\2\f_\3\2\2\2\16j\3\2\2\2\20")
-        buf.write(u"\u00a4\3\2\2\2\22\u00a6\3\2\2\2\24\u00ab\3\2\2\2\26\u00af")
-        buf.write(u"\3\2\2\2\30\u00b3\3\2\2\2\32\u00b9\3\2\2\2\34\u00bb\3")
-        buf.write(u"\2\2\2\36\u00c3\3\2\2\2 \u00d9\3\2\2\2\"\u00dd\3\2\2")
-        buf.write(u"\2$\u00df\3\2\2\2&\'\5\4\3\2\'\3\3\2\2\2()\b\3\1\2)*")
-        buf.write(u"\5\6\4\2*\60\3\2\2\2+,\f\4\2\2,-\7\r\2\2-/\5\4\3\5.+")
-        buf.write(u"\3\2\2\2/\62\3\2\2\2\60.\3\2\2\2\60\61\3\2\2\2\61\5\3")
-        buf.write(u"\2\2\2\62\60\3\2\2\2\63\64\b\4\1\2\64\65\5\b\5\2\65;")
-        buf.write(u"\3\2\2\2\66\67\f\4\2\2\678\7\13\2\28:\5\6\4\59\66\3\2")
-        buf.write(u"\2\2:=\3\2\2\2;9\3\2\2\2;<\3\2\2\2<\7\3\2\2\2=;\3\2\2")
-        buf.write(u"\2>?\b\5\1\2?@\5\n\6\2@F\3\2\2\2AB\f\4\2\2BC\7\n\2\2")
-        buf.write(u"CE\5\b\5\5DA\3\2\2\2EH\3\2\2\2FD\3\2\2\2FG\3\2\2\2G\t")
-        buf.write(u"\3\2\2\2HF\3\2\2\2IJ\b\6\1\2JK\7+\2\2KL\5\f\7\2LM\7*")
-        buf.write(u"\2\2MS\3\2\2\2NO\7)\2\2OP\5\4\3\2PQ\7(\2\2QS\3\2\2\2")
-        buf.write(u"RI\3\2\2\2RN\3\2\2\2S\\\3\2\2\2TU\f\5\2\2U[\5\22\n\2")
-        buf.write(u"VW\f\4\2\2W[\5\24\13\2XY\f\3\2\2Y[\5\26\f\2ZT\3\2\2\2")
-        buf.write(u"ZV\3\2\2\2ZX\3\2\2\2[^\3\2\2\2\\Z\3\2\2\2\\]\3\2\2\2")
-        buf.write(u"]\13\3\2\2\2^\\\3\2\2\2_`\b\7\1\2`a\5\16\b\2ag\3\2\2")
-        buf.write(u"\2bc\f\4\2\2cd\7\13\2\2df\5\f\7\5eb\3\2\2\2fi\3\2\2\2")
-        buf.write(u"ge\3\2\2\2gh\3\2\2\2h\r\3\2\2\2ig\3\2\2\2jk\b\b\1\2k")
-        buf.write(u"l\5\20\t\2lr\3\2\2\2mn\f\4\2\2no\7\n\2\2oq\5\16\b\5p")
-        buf.write(u"m\3\2\2\2qt\3\2\2\2rp\3\2\2\2rs\3\2\2\2s\17\3\2\2\2t")
-        buf.write(u"r\3\2\2\2uv\5\30\r\2vw\t\2\2\2wx\5\"\22\2x\u00a5\3\2")
-        buf.write(u"\2\2yz\5\30\r\2z{\t\3\2\2{|\5$\23\2|\u00a5\3\2\2\2}\177")
-        buf.write(u"\5\30\r\2~\u0080\7\f\2\2\177~\3\2\2\2\177\u0080\3\2\2")
-        buf.write(u"\2\u0080\u0081\3\2\2\2\u0081\u0082\7\23\2\2\u0082\u0083")
-        buf.write(u"\5 \21\2\u0083\u00a5\3\2\2\2\u0084\u0086\5\30\r\2\u0085")
-        buf.write(u"\u0087\7\f\2\2\u0086\u0085\3\2\2\2\u0086\u0087\3\2\2")
-        buf.write(u"\2\u0087\u0088\3\2\2\2\u0088\u0089\7\16\2\2\u0089\u008a")
-        buf.write(u"\7\7\2\2\u008a\u00a5\3\2\2\2\u008b\u008d\5\30\r\2\u008c")
-        buf.write(u"\u008e\7\f\2\2\u008d\u008c\3\2\2\2\u008d\u008e\3\2\2")
-        buf.write(u"\2\u008e\u008f\3\2\2\2\u008f\u0090\7\17\2\2\u0090\u0091")
-        buf.write(u"\7\7\2\2\u0091\u00a5\3\2\2\2\u0092\u0094\5\30\r\2\u0093")
-        buf.write(u"\u0095\7\f\2\2\u0094\u0093\3\2\2\2\u0094\u0095\3\2\2")
-        buf.write(u"\2\u0095\u0096\3\2\2\2\u0096\u0097\7\21\2\2\u0097\u0098")
-        buf.write(u"\7\7\2\2\u0098\u00a5\3\2\2\2\u0099\u009b\5\30\r\2\u009a")
-        buf.write(u"\u009c\7\f\2\2\u009b\u009a\3\2\2\2\u009b\u009c\3\2\2")
-        buf.write(u"\2\u009c\u009d\3\2\2\2\u009d\u009e\7\20\2\2\u009e\u009f")
-        buf.write(u"\7\7\2\2\u009f\u00a5\3\2\2\2\u00a0\u00a1\7)\2\2\u00a1")
-        buf.write(u"\u00a2\5\f\7\2\u00a2\u00a3\7(\2\2\u00a3\u00a5\3\2\2\2")
-        buf.write(u"\u00a4u\3\2\2\2\u00a4y\3\2\2\2\u00a4}\3\2\2\2\u00a4\u0084")
-        buf.write(u"\3\2\2\2\u00a4\u008b\3\2\2\2\u00a4\u0092\3\2\2\2\u00a4")
-        buf.write(u"\u0099\3\2\2\2\u00a4\u00a0\3\2\2\2\u00a5\21\3\2\2\2\u00a6")
-        buf.write(u"\u00a7\7\24\2\2\u00a7\u00a8\7\7\2\2\u00a8\u00a9\7\25")
-        buf.write(u"\2\2\u00a9\u00aa\7\7\2\2\u00aa\23\3\2\2\2\u00ab\u00ac")
-        buf.write(u"\7\31\2\2\u00ac\u00ad\t\4\2\2\u00ad\u00ae\7\26\2\2\u00ae")
-        buf.write(u"\25\3\2\2\2\u00af\u00b0\7\32\2\2\u00b0\u00b1\7\3\2\2")
-        buf.write(u"\u00b1\u00b2\7\33\2\2\u00b2\27\3\2\2\2\u00b3\u00b4\5")
-        buf.write(u"\32\16\2\u00b4\u00b5\7%\2\2\u00b5\u00b7\5\34\17\2\u00b6")
-        buf.write(u"\u00b8\5\36\20\2\u00b7\u00b6\3\2\2\2\u00b7\u00b8\3\2")
-        buf.write(u"\2\2\u00b8\31\3\2\2\2\u00b9\u00ba\t\5\2\2\u00ba\33\3")
-        buf.write(u"\2\2\2\u00bb\u00bc\t\6\2\2\u00bc\35\3\2\2\2\u00bd\u00be")
-        buf.write(u"\b\20\1\2\u00be\u00bf\7&\2\2\u00bf\u00c4\t\6\2\2\u00c0")
-        buf.write(u"\u00c1\7+\2\2\u00c1\u00c2\t\7\2\2\u00c2\u00c4\7*\2\2")
-        buf.write(u"\u00c3\u00bd\3\2\2\2\u00c3\u00c0\3\2\2\2\u00c4\u00c9")
-        buf.write(u"\3\2\2\2\u00c5\u00c6\f\5\2\2\u00c6\u00c8\5\36\20\6\u00c7")
-        buf.write(u"\u00c5\3\2\2\2\u00c8\u00cb\3\2\2\2\u00c9\u00c7\3\2\2")
-        buf.write(u"\2\u00c9\u00ca\3\2\2\2\u00ca\37\3\2\2\2\u00cb\u00c9\3")
-        buf.write(u"\2\2\2\u00cc\u00cd\7)\2\2\u00cd\u00da\7(\2\2\u00ce\u00cf")
-        buf.write(u"\7)\2\2\u00cf\u00d4\5\"\22\2\u00d0\u00d1\7\'\2\2\u00d1")
-        buf.write(u"\u00d3\5\"\22\2\u00d2\u00d0\3\2\2\2\u00d3\u00d6\3\2\2")
-        buf.write(u"\2\u00d4\u00d2\3\2\2\2\u00d4\u00d5\3\2\2\2\u00d5\u00d7")
-        buf.write(u"\3\2\2\2\u00d6\u00d4\3\2\2\2\u00d7\u00d8\7(\2\2\u00d8")
-        buf.write(u"\u00da\3\2\2\2\u00d9\u00cc\3\2\2\2\u00d9\u00ce\3\2\2")
-        buf.write(u"\2\u00da!\3\2\2\2\u00db\u00de\5$\23\2\u00dc\u00de\7\b")
-        buf.write(u"\2\2\u00dd\u00db\3\2\2\2\u00dd\u00dc\3\2\2\2\u00de#\3")
-        buf.write(u"\2\2\2\u00df\u00e0\t\b\2\2\u00e0%\3\2\2\2\26\60;FRZ\\")
-        buf.write(u"gr\177\u0086\u008d\u0094\u009b\u00a4\u00b7\u00c3\u00c9")
-        buf.write(u"\u00d4\u00d9\u00dd")
+        buf.write(u"\b\3\b\3\b\3\b\7\bq\n\b\f\b\16\bt\13\b\3\t\3\t\5\tx\n")
+        buf.write(u"\t\3\t\3\t\3\t\3\t\3\t\5\t\177\n\t\3\t\3\t\3\t\3\t\3")
+        buf.write(u"\t\5\t\u0086\n\t\3\t\3\t\3\t\3\t\3\t\5\t\u008d\n\t\3")
+        buf.write(u"\t\3\t\3\t\3\t\3\t\5\t\u0094\n\t\3\t\3\t\3\t\3\t\3\t")
+        buf.write(u"\5\t\u009b\n\t\3\t\3\t\3\t\3\t\3\t\5\t\u00a2\n\t\3\t")
+        buf.write(u"\3\t\3\t\3\t\3\t\3\t\3\t\5\t\u00ab\n\t\3\n\3\n\3\n\3")
+        buf.write(u"\n\3\n\3\13\3\13\3\13\3\13\3\f\3\f\3\f\3\f\3\r\3\r\3")
+        buf.write(u"\r\3\r\5\r\u00be\n\r\3\16\3\16\3\17\3\17\3\20\3\20\3")
+        buf.write(u"\20\3\20\3\20\3\20\5\20\u00ca\n\20\3\20\3\20\7\20\u00ce")
+        buf.write(u"\n\20\f\20\16\20\u00d1\13\20\3\21\3\21\3\21\3\21\3\21")
+        buf.write(u"\3\21\7\21\u00d9\n\21\f\21\16\21\u00dc\13\21\3\21\3\21")
+        buf.write(u"\5\21\u00e0\n\21\3\22\3\22\5\22\u00e4\n\22\3\23\3\23")
+        buf.write(u"\3\23\2\t\4\6\b\n\f\16\36\24\2\4\6\b\n\f\16\20\22\24")
+        buf.write(u"\26\30\32\34\36 \"$\2\t\3\2\36\37\3\2 #\3\2\3\4\3\2\34")
+        buf.write(u"\35\4\2\7\7\34\34\4\2\3\3\61\61\4\2\3\7\t\t\2\u00f2\2")
+        buf.write(u"&\3\2\2\2\4(\3\2\2\2\6\63\3\2\2\2\b>\3\2\2\2\nR\3\2\2")
+        buf.write(u"\2\f_\3\2\2\2\16j\3\2\2\2\20\u00aa\3\2\2\2\22\u00ac\3")
+        buf.write(u"\2\2\2\24\u00b1\3\2\2\2\26\u00b5\3\2\2\2\30\u00b9\3\2")
+        buf.write(u"\2\2\32\u00bf\3\2\2\2\34\u00c1\3\2\2\2\36\u00c9\3\2\2")
+        buf.write(u"\2 \u00df\3\2\2\2\"\u00e3\3\2\2\2$\u00e5\3\2\2\2&\'\5")
+        buf.write(u"\4\3\2\'\3\3\2\2\2()\b\3\1\2)*\5\6\4\2*\60\3\2\2\2+,")
+        buf.write(u"\f\4\2\2,-\7\r\2\2-/\5\4\3\5.+\3\2\2\2/\62\3\2\2\2\60")
+        buf.write(u".\3\2\2\2\60\61\3\2\2\2\61\5\3\2\2\2\62\60\3\2\2\2\63")
+        buf.write(u"\64\b\4\1\2\64\65\5\b\5\2\65;\3\2\2\2\66\67\f\4\2\2\67")
+        buf.write(u"8\7\13\2\28:\5\6\4\59\66\3\2\2\2:=\3\2\2\2;9\3\2\2\2")
+        buf.write(u";<\3\2\2\2<\7\3\2\2\2=;\3\2\2\2>?\b\5\1\2?@\5\n\6\2@")
+        buf.write(u"F\3\2\2\2AB\f\4\2\2BC\7\n\2\2CE\5\b\5\5DA\3\2\2\2EH\3")
+        buf.write(u"\2\2\2FD\3\2\2\2FG\3\2\2\2G\t\3\2\2\2HF\3\2\2\2IJ\b\6")
+        buf.write(u"\1\2JK\7+\2\2KL\5\f\7\2LM\7*\2\2MS\3\2\2\2NO\7)\2\2O")
+        buf.write(u"P\5\4\3\2PQ\7(\2\2QS\3\2\2\2RI\3\2\2\2RN\3\2\2\2S\\\3")
+        buf.write(u"\2\2\2TU\f\5\2\2U[\5\22\n\2VW\f\4\2\2W[\5\24\13\2XY\f")
+        buf.write(u"\3\2\2Y[\5\26\f\2ZT\3\2\2\2ZV\3\2\2\2ZX\3\2\2\2[^\3\2")
+        buf.write(u"\2\2\\Z\3\2\2\2\\]\3\2\2\2]\13\3\2\2\2^\\\3\2\2\2_`\b")
+        buf.write(u"\7\1\2`a\5\16\b\2ag\3\2\2\2bc\f\4\2\2cd\7\13\2\2df\5")
+        buf.write(u"\f\7\5eb\3\2\2\2fi\3\2\2\2ge\3\2\2\2gh\3\2\2\2h\r\3\2")
+        buf.write(u"\2\2ig\3\2\2\2jk\b\b\1\2kl\5\20\t\2lr\3\2\2\2mn\f\4\2")
+        buf.write(u"\2no\7\n\2\2oq\5\16\b\5pm\3\2\2\2qt\3\2\2\2rp\3\2\2\2")
+        buf.write(u"rs\3\2\2\2s\17\3\2\2\2tr\3\2\2\2uw\5\30\r\2vx\7\f\2\2")
+        buf.write(u"wv\3\2\2\2wx\3\2\2\2xy\3\2\2\2yz\t\2\2\2z{\5\"\22\2{")
+        buf.write(u"\u00ab\3\2\2\2|~\5\30\r\2}\177\7\f\2\2~}\3\2\2\2~\177")
+        buf.write(u"\3\2\2\2\177\u0080\3\2\2\2\u0080\u0081\t\3\2\2\u0081")
+        buf.write(u"\u0082\5$\23\2\u0082\u00ab\3\2\2\2\u0083\u0085\5\30\r")
+        buf.write(u"\2\u0084\u0086\7\f\2\2\u0085\u0084\3\2\2\2\u0085\u0086")
+        buf.write(u"\3\2\2\2\u0086\u0087\3\2\2\2\u0087\u0088\7\23\2\2\u0088")
+        buf.write(u"\u0089\5 \21\2\u0089\u00ab\3\2\2\2\u008a\u008c\5\30\r")
+        buf.write(u"\2\u008b\u008d\7\f\2\2\u008c\u008b\3\2\2\2\u008c\u008d")
+        buf.write(u"\3\2\2\2\u008d\u008e\3\2\2\2\u008e\u008f\7\16\2\2\u008f")
+        buf.write(u"\u0090\7\7\2\2\u0090\u00ab\3\2\2\2\u0091\u0093\5\30\r")
+        buf.write(u"\2\u0092\u0094\7\f\2\2\u0093\u0092\3\2\2\2\u0093\u0094")
+        buf.write(u"\3\2\2\2\u0094\u0095\3\2\2\2\u0095\u0096\7\17\2\2\u0096")
+        buf.write(u"\u0097\7\7\2\2\u0097\u00ab\3\2\2\2\u0098\u009a\5\30\r")
+        buf.write(u"\2\u0099\u009b\7\f\2\2\u009a\u0099\3\2\2\2\u009a\u009b")
+        buf.write(u"\3\2\2\2\u009b\u009c\3\2\2\2\u009c\u009d\7\21\2\2\u009d")
+        buf.write(u"\u009e\7\7\2\2\u009e\u00ab\3\2\2\2\u009f\u00a1\5\30\r")
+        buf.write(u"\2\u00a0\u00a2\7\f\2\2\u00a1\u00a0\3\2\2\2\u00a1\u00a2")
+        buf.write(u"\3\2\2\2\u00a2\u00a3\3\2\2\2\u00a3\u00a4\7\20\2\2\u00a4")
+        buf.write(u"\u00a5\7\7\2\2\u00a5\u00ab\3\2\2\2\u00a6\u00a7\7)\2\2")
+        buf.write(u"\u00a7\u00a8\5\f\7\2\u00a8\u00a9\7(\2\2\u00a9\u00ab\3")
+        buf.write(u"\2\2\2\u00aau\3\2\2\2\u00aa|\3\2\2\2\u00aa\u0083\3\2")
+        buf.write(u"\2\2\u00aa\u008a\3\2\2\2\u00aa\u0091\3\2\2\2\u00aa\u0098")
+        buf.write(u"\3\2\2\2\u00aa\u009f\3\2\2\2\u00aa\u00a6\3\2\2\2\u00ab")
+        buf.write(u"\21\3\2\2\2\u00ac\u00ad\7\24\2\2\u00ad\u00ae\7\7\2\2")
+        buf.write(u"\u00ae\u00af\7\25\2\2\u00af\u00b0\7\7\2\2\u00b0\23\3")
+        buf.write(u"\2\2\2\u00b1\u00b2\7\31\2\2\u00b2\u00b3\t\4\2\2\u00b3")
+        buf.write(u"\u00b4\7\26\2\2\u00b4\25\3\2\2\2\u00b5\u00b6\7\32\2\2")
+        buf.write(u"\u00b6\u00b7\7\3\2\2\u00b7\u00b8\7\33\2\2\u00b8\27\3")
+        buf.write(u"\2\2\2\u00b9\u00ba\5\32\16\2\u00ba\u00bb\7%\2\2\u00bb")
+        buf.write(u"\u00bd\5\34\17\2\u00bc\u00be\5\36\20\2\u00bd\u00bc\3")
+        buf.write(u"\2\2\2\u00bd\u00be\3\2\2\2\u00be\31\3\2\2\2\u00bf\u00c0")
+        buf.write(u"\t\5\2\2\u00c0\33\3\2\2\2\u00c1\u00c2\t\6\2\2\u00c2\35")
+        buf.write(u"\3\2\2\2\u00c3\u00c4\b\20\1\2\u00c4\u00c5\7&\2\2\u00c5")
+        buf.write(u"\u00ca\t\6\2\2\u00c6\u00c7\7+\2\2\u00c7\u00c8\t\7\2\2")
+        buf.write(u"\u00c8\u00ca\7*\2\2\u00c9\u00c3\3\2\2\2\u00c9\u00c6\3")
+        buf.write(u"\2\2\2\u00ca\u00cf\3\2\2\2\u00cb\u00cc\f\5\2\2\u00cc")
+        buf.write(u"\u00ce\5\36\20\6\u00cd\u00cb\3\2\2\2\u00ce\u00d1\3\2")
+        buf.write(u"\2\2\u00cf\u00cd\3\2\2\2\u00cf\u00d0\3\2\2\2\u00d0\37")
+        buf.write(u"\3\2\2\2\u00d1\u00cf\3\2\2\2\u00d2\u00d3\7)\2\2\u00d3")
+        buf.write(u"\u00e0\7(\2\2\u00d4\u00d5\7)\2\2\u00d5\u00da\5\"\22\2")
+        buf.write(u"\u00d6\u00d7\7\'\2\2\u00d7\u00d9\5\"\22\2\u00d8\u00d6")
+        buf.write(u"\3\2\2\2\u00d9\u00dc\3\2\2\2\u00da\u00d8\3\2\2\2\u00da")
+        buf.write(u"\u00db\3\2\2\2\u00db\u00dd\3\2\2\2\u00dc\u00da\3\2\2")
+        buf.write(u"\2\u00dd\u00de\7(\2\2\u00de\u00e0\3\2\2\2\u00df\u00d2")
+        buf.write(u"\3\2\2\2\u00df\u00d4\3\2\2\2\u00e0!\3\2\2\2\u00e1\u00e4")
+        buf.write(u"\5$\23\2\u00e2\u00e4\7\b\2\2\u00e3\u00e1\3\2\2\2\u00e3")
+        buf.write(u"\u00e2\3\2\2\2\u00e4#\3\2\2\2\u00e5\u00e6\t\b\2\2\u00e6")
+        buf.write(u"%\3\2\2\2\30\60;FRZ\\grw~\u0085\u008c\u0093\u009a\u00a1")
+        buf.write(u"\u00aa\u00bd\u00c9\u00cf\u00da\u00df\u00e3")
         return buf.getvalue()
 
 
@@ -925,6 +928,8 @@ class STIXPatternParser ( Parser ):
             return self.getToken(STIXPatternParser.GE, 0)
         def LE(self):
             return self.getToken(STIXPatternParser.LE, 0)
+        def NOT(self):
+            return self.getToken(STIXPatternParser.NOT, 0)
 
         def enterRule(self, listener):
             if hasattr(listener, "enterPropTestOrder"):
@@ -976,6 +981,8 @@ class STIXPatternParser ( Parser ):
             return self.getToken(STIXPatternParser.EQ, 0)
         def NEQ(self):
             return self.getToken(STIXPatternParser.NEQ, 0)
+        def NOT(self):
+            return self.getToken(STIXPatternParser.NOT, 0)
 
         def enterRule(self, listener):
             if hasattr(listener, "enterPropTestEqual"):
@@ -1092,144 +1099,160 @@ class STIXPatternParser ( Parser ):
         self.enterRule(localctx, 14, self.RULE_propTest)
         self._la = 0 # Token type
         try:
-            self.state = 162
+            self.state = 168
             self._errHandler.sync(self)
-            la_ = self._interp.adaptivePredict(self._input,13,self._ctx)
+            la_ = self._interp.adaptivePredict(self._input,15,self._ctx)
             if la_ == 1:
                 localctx = STIXPatternParser.PropTestEqualContext(self, localctx)
                 self.enterOuterAlt(localctx, 1)
                 self.state = 115
                 self.objectPath()
-                self.state = 116
+                self.state = 117
+                self._errHandler.sync(self)
+                _la = self._input.LA(1)
+                if _la==STIXPatternParser.NOT:
+                    self.state = 116
+                    self.match(STIXPatternParser.NOT)
+
+
+                self.state = 119
                 _la = self._input.LA(1)
                 if not(_la==STIXPatternParser.EQ or _la==STIXPatternParser.NEQ):
                     self._errHandler.recoverInline(self)
                 else:
                     self._errHandler.reportMatch(self)
                     self.consume()
-                self.state = 117
+                self.state = 120
                 self.primitiveLiteral()
                 pass
 
             elif la_ == 2:
                 localctx = STIXPatternParser.PropTestOrderContext(self, localctx)
                 self.enterOuterAlt(localctx, 2)
-                self.state = 119
+                self.state = 122
                 self.objectPath()
-                self.state = 120
+                self.state = 124
+                self._errHandler.sync(self)
+                _la = self._input.LA(1)
+                if _la==STIXPatternParser.NOT:
+                    self.state = 123
+                    self.match(STIXPatternParser.NOT)
+
+
+                self.state = 126
                 _la = self._input.LA(1)
                 if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << STIXPatternParser.LT) | (1 << STIXPatternParser.LE) | (1 << STIXPatternParser.GT) | (1 << STIXPatternParser.GE))) != 0)):
                     self._errHandler.recoverInline(self)
                 else:
                     self._errHandler.reportMatch(self)
                     self.consume()
-                self.state = 121
+                self.state = 127
                 self.orderableLiteral()
                 pass
 
             elif la_ == 3:
                 localctx = STIXPatternParser.PropTestSetContext(self, localctx)
                 self.enterOuterAlt(localctx, 3)
-                self.state = 123
+                self.state = 129
                 self.objectPath()
-                self.state = 125
+                self.state = 131
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 if _la==STIXPatternParser.NOT:
-                    self.state = 124
+                    self.state = 130
                     self.match(STIXPatternParser.NOT)
 
 
-                self.state = 127
+                self.state = 133
                 self.match(STIXPatternParser.IN)
-                self.state = 128
+                self.state = 134
                 self.setLiteral()
                 pass
 
             elif la_ == 4:
                 localctx = STIXPatternParser.PropTestLikeContext(self, localctx)
                 self.enterOuterAlt(localctx, 4)
-                self.state = 130
+                self.state = 136
                 self.objectPath()
-                self.state = 132
+                self.state = 138
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 if _la==STIXPatternParser.NOT:
-                    self.state = 131
+                    self.state = 137
                     self.match(STIXPatternParser.NOT)
 
 
-                self.state = 134
+                self.state = 140
                 self.match(STIXPatternParser.LIKE)
-                self.state = 135
+                self.state = 141
                 self.match(STIXPatternParser.StringLiteral)
                 pass
 
             elif la_ == 5:
                 localctx = STIXPatternParser.PropTestRegexContext(self, localctx)
                 self.enterOuterAlt(localctx, 5)
-                self.state = 137
+                self.state = 143
                 self.objectPath()
-                self.state = 139
+                self.state = 145
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 if _la==STIXPatternParser.NOT:
-                    self.state = 138
+                    self.state = 144
                     self.match(STIXPatternParser.NOT)
 
 
-                self.state = 141
+                self.state = 147
                 self.match(STIXPatternParser.MATCHES)
-                self.state = 142
+                self.state = 148
                 self.match(STIXPatternParser.StringLiteral)
                 pass
 
             elif la_ == 6:
                 localctx = STIXPatternParser.PropTestIsSubsetContext(self, localctx)
                 self.enterOuterAlt(localctx, 6)
-                self.state = 144
+                self.state = 150
                 self.objectPath()
-                self.state = 146
+                self.state = 152
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 if _la==STIXPatternParser.NOT:
-                    self.state = 145
+                    self.state = 151
                     self.match(STIXPatternParser.NOT)
 
 
-                self.state = 148
+                self.state = 154
                 self.match(STIXPatternParser.ISSUBSET)
-                self.state = 149
+                self.state = 155
                 self.match(STIXPatternParser.StringLiteral)
                 pass
 
             elif la_ == 7:
                 localctx = STIXPatternParser.PropTestIsSupersetContext(self, localctx)
                 self.enterOuterAlt(localctx, 7)
-                self.state = 151
+                self.state = 157
                 self.objectPath()
-                self.state = 153
+                self.state = 159
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 if _la==STIXPatternParser.NOT:
-                    self.state = 152
+                    self.state = 158
                     self.match(STIXPatternParser.NOT)
 
 
-                self.state = 155
+                self.state = 161
                 self.match(STIXPatternParser.ISSUPERSET)
-                self.state = 156
+                self.state = 162
                 self.match(STIXPatternParser.StringLiteral)
                 pass
 
             elif la_ == 8:
                 localctx = STIXPatternParser.PropTestParenContext(self, localctx)
                 self.enterOuterAlt(localctx, 8)
-                self.state = 158
+                self.state = 164
                 self.match(STIXPatternParser.LPAREN)
-                self.state = 159
+                self.state = 165
                 self.comparisonExpression(0)
-                self.state = 160
+                self.state = 166
                 self.match(STIXPatternParser.RPAREN)
                 pass
 
@@ -1280,13 +1303,13 @@ class STIXPatternParser ( Parser ):
         self.enterRule(localctx, 16, self.RULE_startStopQualifier)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 164
+            self.state = 170
             self.match(STIXPatternParser.START)
-            self.state = 165
+            self.state = 171
             self.match(STIXPatternParser.StringLiteral)
-            self.state = 166
+            self.state = 172
             self.match(STIXPatternParser.STOP)
-            self.state = 167
+            self.state = 173
             self.match(STIXPatternParser.StringLiteral)
         except RecognitionException as re:
             localctx.exception = re
@@ -1335,16 +1358,16 @@ class STIXPatternParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 169
+            self.state = 175
             self.match(STIXPatternParser.WITHIN)
-            self.state = 170
+            self.state = 176
             _la = self._input.LA(1)
             if not(_la==STIXPatternParser.IntLiteral or _la==STIXPatternParser.FloatLiteral):
                 self._errHandler.recoverInline(self)
             else:
                 self._errHandler.reportMatch(self)
                 self.consume()
-            self.state = 171
+            self.state = 177
             self.match(STIXPatternParser.SECONDS)
         except RecognitionException as re:
             localctx.exception = re
@@ -1389,11 +1412,11 @@ class STIXPatternParser ( Parser ):
         self.enterRule(localctx, 20, self.RULE_repeatedQualifier)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 173
+            self.state = 179
             self.match(STIXPatternParser.REPEATS)
-            self.state = 174
+            self.state = 180
             self.match(STIXPatternParser.IntLiteral)
-            self.state = 175
+            self.state = 181
             self.match(STIXPatternParser.TIMES)
         except RecognitionException as re:
             localctx.exception = re
@@ -1445,17 +1468,17 @@ class STIXPatternParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 177
+            self.state = 183
             self.objectType()
-            self.state = 178
+            self.state = 184
             self.match(STIXPatternParser.COLON)
-            self.state = 179
+            self.state = 185
             self.firstPathComponent()
-            self.state = 181
+            self.state = 187
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==STIXPatternParser.DOT or _la==STIXPatternParser.LBRACK:
-                self.state = 180
+                self.state = 186
                 self.objectPathComponent(0)
 
 
@@ -1500,7 +1523,7 @@ class STIXPatternParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 183
+            self.state = 189
             _la = self._input.LA(1)
             if not(_la==STIXPatternParser.IdentifierWithoutHyphen or _la==STIXPatternParser.IdentifierWithHyphen):
                 self._errHandler.recoverInline(self)
@@ -1548,7 +1571,7 @@ class STIXPatternParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 185
+            self.state = 191
             _la = self._input.LA(1)
             if not(_la==STIXPatternParser.StringLiteral or _la==STIXPatternParser.IdentifierWithoutHyphen):
                 self._errHandler.recoverInline(self)
@@ -1655,7 +1678,7 @@ class STIXPatternParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 193
+            self.state = 199
             self._errHandler.sync(self)
             token = self._input.LA(1)
             if token in [STIXPatternParser.DOT]:
@@ -1663,9 +1686,9 @@ class STIXPatternParser ( Parser ):
                 self._ctx = localctx
                 _prevctx = localctx
 
-                self.state = 188
+                self.state = 194
                 self.match(STIXPatternParser.DOT)
-                self.state = 189
+                self.state = 195
                 _la = self._input.LA(1)
                 if not(_la==STIXPatternParser.StringLiteral or _la==STIXPatternParser.IdentifierWithoutHyphen):
                     self._errHandler.recoverInline(self)
@@ -1677,25 +1700,25 @@ class STIXPatternParser ( Parser ):
                 localctx = STIXPatternParser.IndexPathStepContext(self, localctx)
                 self._ctx = localctx
                 _prevctx = localctx
-                self.state = 190
+                self.state = 196
                 self.match(STIXPatternParser.LBRACK)
-                self.state = 191
+                self.state = 197
                 _la = self._input.LA(1)
                 if not(_la==STIXPatternParser.IntLiteral or _la==STIXPatternParser.ASTERISK):
                     self._errHandler.recoverInline(self)
                 else:
                     self._errHandler.reportMatch(self)
                     self.consume()
-                self.state = 192
+                self.state = 198
                 self.match(STIXPatternParser.RBRACK)
                 pass
             else:
                 raise NoViableAltException(self)
 
             self._ctx.stop = self._input.LT(-1)
-            self.state = 199
+            self.state = 205
             self._errHandler.sync(self)
-            _alt = self._interp.adaptivePredict(self._input,16,self._ctx)
+            _alt = self._interp.adaptivePredict(self._input,18,self._ctx)
             while _alt!=2 and _alt!=ATN.INVALID_ALT_NUMBER:
                 if _alt==1:
                     if self._parseListeners is not None:
@@ -1703,15 +1726,15 @@ class STIXPatternParser ( Parser ):
                     _prevctx = localctx
                     localctx = STIXPatternParser.PathStepContext(self, STIXPatternParser.ObjectPathComponentContext(self, _parentctx, _parentState))
                     self.pushNewRecursionContext(localctx, _startState, self.RULE_objectPathComponent)
-                    self.state = 195
+                    self.state = 201
                     if not self.precpred(self._ctx, 3):
                         from antlr4.error.Errors import FailedPredicateException
                         raise FailedPredicateException(self, "self.precpred(self._ctx, 3)")
-                    self.state = 196
+                    self.state = 202
                     self.objectPathComponent(4) 
-                self.state = 201
+                self.state = 207
                 self._errHandler.sync(self)
-                _alt = self._interp.adaptivePredict(self._input,16,self._ctx)
+                _alt = self._interp.adaptivePredict(self._input,18,self._ctx)
 
         except RecognitionException as re:
             localctx.exception = re
@@ -1766,36 +1789,36 @@ class STIXPatternParser ( Parser ):
         self.enterRule(localctx, 30, self.RULE_setLiteral)
         self._la = 0 # Token type
         try:
-            self.state = 215
+            self.state = 221
             self._errHandler.sync(self)
-            la_ = self._interp.adaptivePredict(self._input,18,self._ctx)
+            la_ = self._interp.adaptivePredict(self._input,20,self._ctx)
             if la_ == 1:
                 self.enterOuterAlt(localctx, 1)
-                self.state = 202
+                self.state = 208
                 self.match(STIXPatternParser.LPAREN)
-                self.state = 203
+                self.state = 209
                 self.match(STIXPatternParser.RPAREN)
                 pass
 
             elif la_ == 2:
                 self.enterOuterAlt(localctx, 2)
-                self.state = 204
-                self.match(STIXPatternParser.LPAREN)
-                self.state = 205
-                self.primitiveLiteral()
                 self.state = 210
+                self.match(STIXPatternParser.LPAREN)
+                self.state = 211
+                self.primitiveLiteral()
+                self.state = 216
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 while _la==STIXPatternParser.COMMA:
-                    self.state = 206
-                    self.match(STIXPatternParser.COMMA)
-                    self.state = 207
-                    self.primitiveLiteral()
                     self.state = 212
+                    self.match(STIXPatternParser.COMMA)
+                    self.state = 213
+                    self.primitiveLiteral()
+                    self.state = 218
                     self._errHandler.sync(self)
                     _la = self._input.LA(1)
 
-                self.state = 213
+                self.state = 219
                 self.match(STIXPatternParser.RPAREN)
                 pass
 
@@ -1840,17 +1863,17 @@ class STIXPatternParser ( Parser ):
         localctx = STIXPatternParser.PrimitiveLiteralContext(self, self._ctx, self.state)
         self.enterRule(localctx, 32, self.RULE_primitiveLiteral)
         try:
-            self.state = 219
+            self.state = 225
             self._errHandler.sync(self)
             token = self._input.LA(1)
             if token in [STIXPatternParser.IntLiteral, STIXPatternParser.FloatLiteral, STIXPatternParser.HexLiteral, STIXPatternParser.BinaryLiteral, STIXPatternParser.StringLiteral, STIXPatternParser.TimestampLiteral]:
                 self.enterOuterAlt(localctx, 1)
-                self.state = 217
+                self.state = 223
                 self.orderableLiteral()
                 pass
             elif token in [STIXPatternParser.BoolLiteral]:
                 self.enterOuterAlt(localctx, 2)
-                self.state = 218
+                self.state = 224
                 self.match(STIXPatternParser.BoolLiteral)
                 pass
             else:
@@ -1909,7 +1932,7 @@ class STIXPatternParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 221
+            self.state = 227
             _la = self._input.LA(1)
             if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << STIXPatternParser.IntLiteral) | (1 << STIXPatternParser.FloatLiteral) | (1 << STIXPatternParser.HexLiteral) | (1 << STIXPatternParser.BinaryLiteral) | (1 << STIXPatternParser.StringLiteral) | (1 << STIXPatternParser.TimestampLiteral))) != 0)):
                 self._errHandler.recoverInline(self)

--- a/stix2patterns/inspector.py
+++ b/stix2patterns/inspector.py
@@ -86,7 +86,8 @@ class InspectionListener(STIXPatternListener):
 
     def exitPropTestEqual(self, ctx):
         op_tok = ctx.EQ() or ctx.NEQ()
-        op_str = op_tok.getText()
+        op_str = u"NOT " if ctx.NOT() else u""
+        op_str += op_tok.getText()
 
         value = ctx.primitiveLiteral().getText()
 
@@ -95,7 +96,8 @@ class InspectionListener(STIXPatternListener):
 
     def exitPropTestOrder(self, ctx):
         op_tok = ctx.GT() or ctx.LT() or ctx.GE() or ctx.LE()
-        op_str = op_tok.getText()
+        op_str = u"NOT " if ctx.NOT() else u""
+        op_str += op_tok.getText()
 
         value = ctx.orderableLiteral().getText()
 

--- a/stix2patterns/test/test_inspector.py
+++ b/stix2patterns/test/test_inspector.py
@@ -46,17 +46,17 @@ def test_observation_ops(pattern, expected_obs_ops):
 @pytest.mark.parametrize(u"pattern,expected_comparisons", [
     (u"[foo:bar = 1]", {u"foo": [([u"bar"], u"=", u"1")]}),
     (u"[foo:bar=1 and foo:baz=2]", {u"foo": [([u"bar"], u"=", u"1"), ([u"baz"], u"=", u"2")]}),
-    (u"[foo:bar=1 or bar:foo<12.3]", {
-        u"foo": [([u"bar"], u"=", u"1")],
+    (u"[foo:bar not !=1 or bar:foo<12.3]", {
+        u"foo": [([u"bar"], u"NOT !=", u"1")],
         u"bar": [([u"foo"], u"<", u"12.3")]
     }),
     (u"[foo:bar=1] or [foo:baz matches '123\\\\d+']", {
         u"foo": [([u"bar"], u"=", u"1"), ([u"baz"], u"MATCHES", u"'123\\\\d+'")]
     }),
-    (u"[foo:bar=1 and bar:foo>33] repeats 12 times or "
+    (u"[foo:bar=1 and bar:foo not >33] repeats 12 times or "
      u"  ([baz:bar issubset '1234'] followedby [baz:quux not like 'a_cd'])", {
         u"foo": [([u"bar"], u"=", u"1")],
-        u"bar": [([u"foo"], u">", u"33")],
+        u"bar": [([u"foo"], u"NOT >", u"33")],
         u"baz": [([u"bar"], u"ISSUBSET", u"'1234'"), ([u"quux"], u"NOT LIKE", u"'a_cd'")]
         }),
     (u"[obj-type:a.b[*][1].'c-d' not issuperset '1.2.3.4/16']", {


### PR DESCRIPTION
Regenerated the parser from the latest grammar which includes
support for the 'NOT' qualifier before equality and order
operators.  Added support for it in the inspector so it shows
up in inspection results.  Inserted 'NOT's into a couple of the
inspector tests, to test it.