### PR TITLE
Additional settings to exclude grammars from checks

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,3 +5,4 @@ known_third_party=antlr4,enum,six,typing
 known_first_party=stix2patterns
 not_skip=__init__.py
 force_sort_within_sections=1
+skip=stix2patterns/grammars/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@
         args:
         - --ignore=F403,F405
         - --max-line-length=160
+        - --exclude=stix2patterns/grammars/*
     -   id: check-merge-conflict
 -   repo: https://github.com/FalconSocial/pre-commit-python-sorter
     sha: b57843b0b874df1d16eb0bef00b868792cb245c2

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,3 @@ tag = True
 
 [bdist_wheel]
 universal = 1
-

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
   flake8
 commands =
   pycodestyle ./stix2patterns
-  flake8
+  flake8 ./stix2patterns
 
 [testenv:isort-check]
 deps = isort
@@ -34,6 +34,7 @@ exclude=grammars
 [flake8]
 ignore=F403,F405
 max-line-length=160
+exclude=grammars
 
 [travis]
 python =


### PR DESCRIPTION
This might be useful in the future, if grammars are updated. Last time I made the changes manually, but it is a lot of effort.

Related to pull #29