### PR TITLE
Fix link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 cti-pattern-validator
 =====================
 
-This is an `OASIS Open Repository
-<https://www.oasis-open.org/resources/open-repositories/>`__.
+This is an `OASIS Open
+Repository <https://www.oasis-open.org/resources/open-repositories/>`__.
 See the `Governance <#governance>`__ section for more information.
 
 The STIX 2 Pattern Validator is a software tool for checking the syntax


### PR DESCRIPTION
Maybe this will fix PyPI? This changes a certain link to how it is in the readmes for the other OASIS Open repos, which do work on PyPI. It's hard to test how it will show up on PyPI, but the readme displayed fine for 0.5.0, and this is one of the things that was changed since that version.