### PR TITLE
Validation Error when pushing error

### DIFF
--- a/stix2patterns/validator.py
+++ b/stix2patterns/validator.py
@@ -70,8 +70,8 @@ def run_validator(pattern):
 
     # replace with easier-to-understand error message
     if not (start[0] == '[' or start == '(['):
-        parseErrListener.err_strings[0] = "FAIL: Error found at line 1:0. " \
-                                          "input is missing square brackets"
+        parseErrListener.err_strings.insert(0, "FAIL: Error found at line 1:0. "
+                                               "input is missing square brackets")
 
     # validate observed objects
     if len(parseErrListener.err_strings) == 0:


### PR DESCRIPTION
Fix exception 'IndexError: list assignment index out of range'.

This exception happens when validating a valid STIX pattern (from the `STIXPatternParser` view) that doesn't start with `[`or `([` but with `<space><space>[` or `(<space>[`.