### PR TITLE
Strip whitespace characters from leading characters

### DIFF
--- a/stix2patterns/helpers.py
+++ b/stix2patterns/helpers.py
@@ -1,0 +1,22 @@
+import string
+
+
+def leading_characters(s, length):
+    """
+    Returns non-whitespace leading characters
+
+    :param str s: The string to process
+    :param int length: The number of characters to return
+    :return: The non-whitespace leading characters
+    :rtype: str or None
+    """
+    if s is None:
+        return None
+
+    stripped = []
+    for char in s:
+        if char not in string.whitespace:
+            stripped.append(char)
+
+    upper_bound = min(length, len(stripped))
+    return ''.join(stripped[:upper_bound])

--- a/stix2patterns/test/test_helpers.py
+++ b/stix2patterns/test/test_helpers.py
@@ -1,0 +1,14 @@
+"""
+Test cases for stix2patterns/helpers.py.
+"""
+
+from stix2patterns.helpers import leading_characters
+
+
+def test_leading_characters():
+
+    assert leading_characters('[file:size = 1280]', 2) == '[f'
+    assert leading_characters(' [file:size = 1280]', 2) == '[f'
+    assert leading_characters('( [file:size = 1280])', 2) == '(['
+    assert leading_characters('[', 2) == '['
+    assert leading_characters(None, 2) is None

--- a/stix2patterns/test/test_validator.py
+++ b/stix2patterns/test/test_validator.py
@@ -85,7 +85,8 @@ PASS_CASES = [
     "[x_whatever:detected == t'2018-03-22T12:11:14.1Z']",
     "[artifact:payload_bin = b'dGhpcyBpcyBhIHRlc3Q=']",
     "[foo:bar=1] REPEATS 9 TIMES",
-    "[network-traffic:start = '2018-04-20T12:36:24.558Z']"
+    "[network-traffic:start = '2018-04-20T12:36:24.558Z']",
+    "( [(network-traffic:dst_port IN(443,6443,8443) AND network-traffic:src_packets != 0) ])",  # Misplaced whitespace
 ]
 
 

--- a/stix2patterns/validator.py
+++ b/stix2patterns/validator.py
@@ -13,6 +13,7 @@ import six
 from . import object_validator
 from .grammars.STIXPatternLexer import STIXPatternLexer
 from .grammars.STIXPatternParser import STIXPatternParser
+from .helpers import leading_characters
 from .inspector import InspectionListener
 
 
@@ -37,11 +38,11 @@ def run_validator(pattern):
     """
     start = ''
     if isinstance(pattern, six.string_types):
-        start = pattern[:2]
+        start = leading_characters(pattern, 2)
         pattern = InputStream(pattern)
 
     if not start:
-        start = pattern.readline()[:2]
+        start = leading_characters(pattern.readline(), 2)
         pattern.seek(0)
 
     parseErrListener = STIXPatternErrorListener()


### PR DESCRIPTION
Fix the issue when STIX pattern starts with white spaces in the leading characters of the pattern.