### PR TITLE
Multi qualifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'antlr4-python3-runtime>=4.7 ; python_version>="3"',
         'six',
         'typing ; python_version<"3.5" and python_version>="3"',
+        'enum34 ; python_version<"3.4"',
     ],
     package_data={
         'stix2patterns.test.v20': ['spec_examples.txt'],

--- a/stix2patterns/inspector.py
+++ b/stix2patterns/inspector.py
@@ -15,9 +15,6 @@ _PatternData = collections.namedtuple("pattern_data",
 INDEX_STAR = object()
 
 
-QualType = enum.Enum("QualType", "WITHIN REPEATS STARTSTOP")
-
-
 def _string_literal_to_string(string_literal_token):
     """Converts the StringLiteral token to a plain string: get text content,
     removes quote characters, and unescapes it.

--- a/stix2patterns/inspector.py
+++ b/stix2patterns/inspector.py
@@ -1,5 +1,4 @@
 import collections
-import enum
 
 
 class InspectionException(Exception):

--- a/stix2patterns/inspector.py
+++ b/stix2patterns/inspector.py
@@ -1,4 +1,5 @@
 import collections
+import enum
 
 
 class InspectionException(Exception):
@@ -12,6 +13,9 @@ _PatternData = collections.namedtuple("pattern_data",
 
 # For representing a "star" array index step in an object path
 INDEX_STAR = object()
+
+
+QualType = enum.Enum("QualType", "WITHIN REPEATS STARTSTOP")
 
 
 def _string_literal_to_string(string_literal_token):

--- a/stix2patterns/test/v21/test_validator.py
+++ b/stix2patterns/test/v21/test_validator.py
@@ -51,7 +51,13 @@ FAIL_CASES = [
     ("[file:hashes.'SHA-256' = 'f00']",  # Malformed hash value
         "FAIL: 'f00' is not a valid SHA-256 hash"),
     ("[win-registry-key:key = 'hkey_local_machine\\\\foo\\\\bar'] WITHIN 5 SECONDS WITHIN 6 SECONDS",
-        "FAIL: The same qualifier is used more than once"),
+        "FAIL: Duplicate qualifier type encountered: WITHIN"),
+    ("([win-registry-key:key = 'hkey_local_machine\\\\foo\\\\bar'] REPEATS 2 TIMES REPEATS 3 TIMES)",
+        "FAIL: Duplicate qualifier type encountered: REPEATS"),
+    ("[win-registry-key:key = 'hkey_local_machine\\\\foo\\\\bar'] "
+     "START t'2016-06-01T01:30:00.123Z' STOP t'2016-06-01T02:20:00.123Z' "
+     "START t'2016-06-01T01:30:00.123Z' STOP t'2016-06-01T02:20:00.123Z'",
+        "FAIL: Duplicate qualifier type encountered: STARTSTOP"),
     # TODO: add more failing test cases.
 ]
 
@@ -89,6 +95,12 @@ PASS_CASES = [
     "[foo:bar=1] REPEATS 9 TIMES",
     "[network-traffic:start = '2018-04-20T12:36:24.558Z']",
     "( [(network-traffic:dst_port IN(443,6443,8443) AND network-traffic:src_packets != 0) ])",  # Misplaced whitespace
+    "([win-registry-key:key = 'hkey_local_machine\\\\foo\\\\bar']) WITHIN 5 SECONDS WITHIN 6 SECONDS",
+    "([win-registry-key:key = 'hkey_local_machine\\\\foo\\\\bar'] REPEATS 2 TIMES) REPEATS 2 TIMES",
+    "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] "
+    "START t'2016-06-01T01:30:00.123Z' STOP t'2016-06-01T02:20:00.123Z' OR "
+    "[ipv4-addr:value = '192.168.122.83'] "
+    "START t'2016-06-01T03:55:00.123Z' STOP t'2016-06-01T04:30:24.743Z'"
 ]
 
 

--- a/stix2patterns/v21/validator.py
+++ b/stix2patterns/v21/validator.py
@@ -6,9 +6,61 @@ from antlr4 import CommonTokenStream, ParseTreeWalker
 
 from . import object_validator
 from ..exceptions import STIXPatternErrorListener
+from ..inspector import QualType
 from .grammars.STIXPatternLexer import STIXPatternLexer
+from .grammars.STIXPatternListener import STIXPatternListener
 from .grammars.STIXPatternParser import STIXPatternParser
 from .inspector import InspectionListener
+
+
+class DuplicateQualifierTypeError(Exception):
+    """
+    Instances represent finding multiple qualifiers of the same type directly
+    applied to an observation expression (i.e. not on some parenthesized group
+    of which the observation expression is a member).
+    """
+    def __init__(self, qual_type):
+        """
+        Initialize this exception instance.
+
+        :param qual_type: The qualifier type which was found to be duplicated.
+            Must be a member of the QualType enum.
+        """
+        message = "Duplicate qualifier type encountered: " + qual_type.name
+
+        super(DuplicateQualifierTypeError, self).__init__(message)
+
+        self.qual_type = qual_type
+
+
+class ValidationListener(STIXPatternListener):
+    """
+    Does some pattern validation via a parse tree traversal.
+    """
+    def __init__(self):
+        self.__qual_types = None
+
+    def __check_qualifier_type(self, qual_type):
+        if self.__qual_types is not None:
+            if qual_type in self.__qual_types:
+                raise DuplicateQualifierTypeError(qual_type)
+            else:
+                self.__qual_types.add(qual_type)
+
+    def exitObservationExpressionSimple(self, ctx):
+        self.__qual_types = set()
+
+    def exitObservationExpressionCompound(self, ctx):
+        self.__qual_types = None
+
+    def exitObservationExpressionWithin(self, ctx):
+        self.__check_qualifier_type(QualType.WITHIN)
+
+    def exitObservationExpressionRepeated(self, ctx):
+        self.__check_qualifier_type(QualType.REPEATS)
+
+    def exitObservationExpressionStartStop(self, ctx):
+        self.__check_qualifier_type(QualType.STARTSTOP)
 
 
 def run_validator(pattern, start):
@@ -38,7 +90,6 @@ def run_validator(pattern, start):
             parser.literalNames[i] = parser.symbolicNames[i]
 
     tree = parser.pattern()
-    inspection_listener = InspectionListener()
 
     # replace with easier-to-understand error message
     if not (start[0] == '[' or start == '(['):
@@ -47,6 +98,7 @@ def run_validator(pattern, start):
 
     # validate observed objects
     if len(parseErrListener.err_strings) == 0:
+        inspection_listener = InspectionListener()
         ParseTreeWalker.DEFAULT.walk(inspection_listener, tree)
         patt_data = inspection_listener.pattern_data()
 
@@ -56,9 +108,9 @@ def run_validator(pattern, start):
             parseErrListener.err_strings.extend(obj_validator_results)
 
         # check qualifiers
-        qualifiers = [q.split()[0] for q in patt_data.qualifiers]
-        if len(qualifiers) != len(set(qualifiers)):
-            parseErrListener.err_strings.insert(0, "FAIL: The same qualifier is"
-                                                   " used more than once")
+        try:
+            ParseTreeWalker.DEFAULT.walk(ValidationListener(), tree)
+        except DuplicateQualifierTypeError as e:
+            parseErrListener.err_strings.insert(0, "FAIL: " + e.args[0])
 
     return parseErrListener.err_strings

--- a/stix2patterns/v21/validator.py
+++ b/stix2patterns/v21/validator.py
@@ -2,15 +2,18 @@
 Validates a user entered pattern against STIXPattern grammar.
 """
 
+import enum
+
 from antlr4 import CommonTokenStream, ParseTreeWalker
 
 from . import object_validator
 from ..exceptions import STIXPatternErrorListener
-from ..inspector import QualType
 from .grammars.STIXPatternLexer import STIXPatternLexer
 from .grammars.STIXPatternListener import STIXPatternListener
 from .grammars.STIXPatternParser import STIXPatternParser
 from .inspector import InspectionListener
+
+QualType = enum.Enum("QualType", "WITHIN REPEATS STARTSTOP")
 
 
 class DuplicateQualifierTypeError(Exception):


### PR DESCRIPTION
In working to fix this we found that the spec was ambiguous: https://github.com/oasis-tcs/cti-stix2/issues/214. However, since consensus in the CTI TC hasn't been reached on this for STIX 2.1, we're interpreting the restriction on multiple qualifiers to only apply to qualifiers applied directly to an observation expression. This means the restriction can be bypassed by adding parentheses, but I think it's better in this case to allow patterns that should be valid than to prevent users from doing something nonsensical. Hopefully the situation will improve with STIX 2.2.

Fixes #66.