### PR TITLE
Fix hash validation code to work with '*' selector

### DIFF
--- a/stix2patterns/test/v20/test_validator.py
+++ b/stix2patterns/test/v20/test_validator.py
@@ -87,6 +87,7 @@ PASS_CASES = [
     "[foo:bar=1] REPEATS 9 TIMES",
     "[network-traffic:start = '2018-04-20T12:36:24.558Z']",
     "( [(network-traffic:dst_port IN(443,6443,8443) AND network-traffic:src_packets != 0) ])",  # Misplaced whitespace
+    "[file:hashes[*] = '8665c8d477534008b3058b72e2dae8ae']",
 ]
 
 

--- a/stix2patterns/test/v21/test_validator.py
+++ b/stix2patterns/test/v21/test_validator.py
@@ -100,7 +100,8 @@ PASS_CASES = [
     "[network-traffic:src_port = 37020 AND user-account:user_id = 'root'] "
     "START t'2016-06-01T01:30:00.123Z' STOP t'2016-06-01T02:20:00.123Z' OR "
     "[ipv4-addr:value = '192.168.122.83'] "
-    "START t'2016-06-01T03:55:00.123Z' STOP t'2016-06-01T04:30:24.743Z'"
+    "START t'2016-06-01T03:55:00.123Z' STOP t'2016-06-01T04:30:24.743Z'",
+    "[file:hashes[*] = '8665c8d477534008b3058b72e2dae8ae']",
 ]
 
 

--- a/stix2patterns/v20/object_validator.py
+++ b/stix2patterns/v20/object_validator.py
@@ -30,9 +30,8 @@ def verify_object(patt_data):
             if 'hashes' in obj_path:
                 hash_selector = obj_path[-1]
                 if hash_selector is not stix2patterns.inspector.INDEX_STAR:
-                    hash_type = str(
+                    hash_type = \
                         hash_selector.upper().replace('-', '').replace("'", "")
-                    )
                     hash_string = value.replace("'", "")
                     if hash_type in HASHES_REGEX:
                         if not re.match(HASHES_REGEX[hash_type][0], hash_string):

--- a/stix2patterns/v20/object_validator.py
+++ b/stix2patterns/v20/object_validator.py
@@ -1,4 +1,5 @@
 import re
+import stix2patterns.inspector
 
 HASHES_REGEX = {
     "MD5": (r"^[a-fA-F0-9]{32}$", "MD5"),
@@ -25,14 +26,17 @@ def verify_object(patt_data):
 
     # iterate over observed objects
     for type_name, comp in patt_data.comparisons.items():
-        for expression in comp:
-            if 'hashes' in expression[0]:
-                hash_type = str(expression[0][-1].upper().replace('-', '').
-                                replace("\'", ""))
-                hash_string = str(expression[2].replace("\'", ""))
-                if hash_type in HASHES_REGEX:
-                    if not re.match(HASHES_REGEX[hash_type][0], hash_string):
-                        error_list.append(
-                            msg.format(hash_string, expression[0][-1])
-                        )
+        for obj_path, op, value in comp:
+            if 'hashes' in obj_path:
+                hash_selector = obj_path[-1]
+                if hash_selector is not stix2patterns.inspector.INDEX_STAR:
+                    hash_type = str(
+                        hash_selector.upper().replace('-', '').replace("'", "")
+                    )
+                    hash_string = value.replace("'", "")
+                    if hash_type in HASHES_REGEX:
+                        if not re.match(HASHES_REGEX[hash_type][0], hash_string):
+                            error_list.append(
+                                msg.format(hash_string, hash_selector)
+                            )
     return error_list

--- a/stix2patterns/v21/object_validator.py
+++ b/stix2patterns/v21/object_validator.py
@@ -30,9 +30,8 @@ def verify_object(patt_data):
             if 'hashes' in obj_path:
                 hash_selector = obj_path[-1]
                 if hash_selector is not stix2patterns.inspector.INDEX_STAR:
-                    hash_type = str(
+                    hash_type = \
                         hash_selector.upper().replace('-', '').replace("'", "")
-                    )
                     hash_string = value.replace("'", "")
                     if hash_type in HASHES_REGEX:
                         if not re.match(HASHES_REGEX[hash_type][0], hash_string):

--- a/stix2patterns/v21/object_validator.py
+++ b/stix2patterns/v21/object_validator.py
@@ -1,4 +1,5 @@
 import re
+import stix2patterns.inspector
 
 HASHES_REGEX = {
     "MD5": (r"^[a-fA-F0-9]{32}$", "MD5"),
@@ -25,14 +26,17 @@ def verify_object(patt_data):
 
     # iterate over observed objects
     for type_name, comp in patt_data.comparisons.items():
-        for expression in comp:
-            if 'hashes' in expression[0]:
-                hash_type = str(expression[0][-1].upper().replace('-', '').
-                                replace("\'", ""))
-                hash_string = str(expression[2].replace("\'", ""))
-                if hash_type in HASHES_REGEX:
-                    if not re.match(HASHES_REGEX[hash_type][0], hash_string):
-                        error_list.append(
-                            msg.format(hash_string, expression[0][-1])
-                        )
+        for obj_path, op, value in comp:
+            if 'hashes' in obj_path:
+                hash_selector = obj_path[-1]
+                if hash_selector is not stix2patterns.inspector.INDEX_STAR:
+                    hash_type = str(
+                        hash_selector.upper().replace('-', '').replace("'", "")
+                    )
+                    hash_string = value.replace("'", "")
+                    if hash_type in HASHES_REGEX:
+                        if not re.match(HASHES_REGEX[hash_type][0], hash_string):
+                            error_list.append(
+                                msg.format(hash_string, hash_selector)
+                            )
     return error_list


### PR DESCRIPTION
Fixes #77 

The hash type can't be determined if '*' is used, so hash validation is skipped in that case.
