### PR TITLE
Fix square bracket checking to account for arbitrary nested parentheses

### DIFF
--- a/stix2patterns/helpers.py
+++ b/stix2patterns/helpers.py
@@ -1,22 +1,30 @@
-import string
+import six
 
 
-def leading_characters(s, length):
+def brackets_check(pattern):
     """
-    Returns non-whitespace leading characters
+    Check whether the pattern is missing square brackets, in a way which does
+    not require the usual parsing.  This is a light hack to provide an improved
+    error message in this particular case.
 
-    :param str s: The string to process
-    :param int length: The number of characters to return
-    :return: The non-whitespace leading characters
-    :rtype: str or None
+    :param pattern: A STIX pattern string
+    :return: True if the pattern had its brackets; False if not
     """
-    if s is None:
-        return None
+    if isinstance(pattern, six.string_types):
+        # the non-whitespace chars
+        non_ws_chars = (c for c in pattern if not c.isspace())
 
-    stripped = []
-    for char in s:
-        if char not in string.whitespace:
-            stripped.append(char)
+        # There can be an arbitrary number of open parens first... skip over those
+        c = next(non_ws_chars, None)
+        while c == "(":
+            c = next(non_ws_chars, None)
 
-    upper_bound = min(length, len(stripped))
-    return ''.join(stripped[:upper_bound])
+        if c == "[":
+            result = True
+        else:
+            result = False
+
+    else:
+        result = False
+
+    return result

--- a/stix2patterns/helpers.py
+++ b/stix2patterns/helpers.py
@@ -11,13 +11,12 @@ def brackets_check(pattern):
     :return: True if the pattern had its brackets; False if not
     """
     if isinstance(pattern, six.string_types):
-        # the non-whitespace chars
-        non_ws_chars = (c for c in pattern if not c.isspace())
 
-        # There can be an arbitrary number of open parens first... skip over those
-        c = next(non_ws_chars, None)
-        while c == "(":
-            c = next(non_ws_chars, None)
+        # There can be an arbitrary number of open parens first... skip over
+        # those
+        for c in pattern:
+            if c != "(" and not c.isspace():
+                break
 
         if c == "[":
             result = True

--- a/stix2patterns/test/test_helpers.py
+++ b/stix2patterns/test/test_helpers.py
@@ -20,5 +20,14 @@ def test_brackets_check(value):
     assert brackets_check(value)
 
 
-def test_brackets_check_fail():
+@pytest.mark.parametrize(
+    "value", [
+        None,
+        "file:size = 1280",
+        "(file:size = 1280)",
+        " ( file:size = 1280 ) ",
+        " (( (( file:size = 1280 ) )) ) ",
+    ]
+)
+def test_brackets_check_fail(value):
     assert not brackets_check(None)

--- a/stix2patterns/test/test_helpers.py
+++ b/stix2patterns/test/test_helpers.py
@@ -1,14 +1,24 @@
 """
 Test cases for stix2patterns/helpers.py.
 """
+import pytest
 
-from stix2patterns.helpers import leading_characters
+from stix2patterns.helpers import brackets_check
 
 
-def test_leading_characters():
+@pytest.mark.parametrize(
+    "value", [
+        '[file:size = 1280]',
+        ' [file:size = 1280]',
+        '( [file:size = 1280])',
+        '( ( [file:size = 1280]) )',
+        '(( ( ( [file:size = 1280])) ))',
+        '[',
+    ],
+)
+def test_brackets_check(value):
+    assert brackets_check(value)
 
-    assert leading_characters('[file:size = 1280]', 2) == '[f'
-    assert leading_characters(' [file:size = 1280]', 2) == '[f'
-    assert leading_characters('( [file:size = 1280])', 2) == '(['
-    assert leading_characters('[', 2) == '['
-    assert leading_characters(None, 2) is None
+
+def test_brackets_check_fail():
+    assert not brackets_check(None)

--- a/stix2patterns/v20/object_validator.py
+++ b/stix2patterns/v20/object_validator.py
@@ -1,4 +1,5 @@
 import re
+
 import stix2patterns.inspector
 
 HASHES_REGEX = {

--- a/stix2patterns/v20/validator.py
+++ b/stix2patterns/v20/validator.py
@@ -11,7 +11,7 @@ from .grammars.STIXPatternParser import STIXPatternParser
 from .inspector import InspectionListener
 
 
-def run_validator(pattern, start):
+def run_validator(pattern):
     """
     Validates a pattern against the STIX Pattern grammar.  Error messages are
     returned in a list.  The test passed if the returned list is empty.
@@ -39,11 +39,6 @@ def run_validator(pattern, start):
 
     tree = parser.pattern()
     inspection_listener = InspectionListener()
-
-    # replace with easier-to-understand error message
-    if not (start[0] == '[' or start == '(['):
-        parseErrListener.err_strings.insert(0, "FAIL: Error found at line 1:0. "
-                                               "input is missing square brackets")
 
     # validate observed objects
     if len(parseErrListener.err_strings) == 0:

--- a/stix2patterns/v21/object_validator.py
+++ b/stix2patterns/v21/object_validator.py
@@ -1,4 +1,5 @@
 import re
+
 import stix2patterns.inspector
 
 HASHES_REGEX = {

--- a/stix2patterns/v21/validator.py
+++ b/stix2patterns/v21/validator.py
@@ -66,7 +66,7 @@ class ValidationListener(STIXPatternListener):
         self.__check_qualifier_type(QualType.STARTSTOP)
 
 
-def run_validator(pattern, start):
+def run_validator(pattern):
     """
     Validates a pattern against the STIX Pattern grammar.  Error messages are
     returned in a list.  The test passed if the returned list is empty.
@@ -93,11 +93,6 @@ def run_validator(pattern, start):
             parser.literalNames[i] = parser.symbolicNames[i]
 
     tree = parser.pattern()
-
-    # replace with easier-to-understand error message
-    if not (start[0] == '[' or start == '(['):
-        parseErrListener.err_strings.insert(0, "FAIL: Error found at line 1:0. "
-                                               "input is missing square brackets")
 
     # validate observed objects
     if len(parseErrListener.err_strings) == 0:


### PR DESCRIPTION
Fixes #80 .

The `leading_characters()` approach doesn't work, since it was designed to get a specific number of non-whitespace characters.  The number of characters necessary to check is unpredictable, so I've redesigned that whole approach.  I renamed the function, and now it doesn't return leading characters since it seemed unnecessary.  Instead, it does the check itself and returns True/False.  The old `start` variable and parameter to the STIX version-specific `run_validator()` functions is removed.  I didn't see any need for the latter functions to add the specialized error message when the caller could do it just as easily.

There were also some minor edits to unrelated files due to pre-commit.