### PR TITLE
Upgrade default pattern to 2.1

### DIFF
--- a/stix2patterns/pattern.py
+++ b/stix2patterns/pattern.py
@@ -1,3 +1,3 @@
 # Update or remove for 2.0.0
 from .exceptions import ParseException, ParserErrorListener  # noqa: F401
-from .v20.pattern import Pattern  # noqa: F401
+from .v21.pattern import Pattern  # noqa: F401


### PR DESCRIPTION
The change permits the usage of importing the v2.1 `Pattern` class from `stix2patterns.pattern` by default instead of v2.0. With this update, this:

```
>>> from stix2patterns.pattern import Pattern
>>> p = Pattern("[file:hashes.'SHA-256' = 'aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f']")
>>> dir(p)
['_Pattern__do_parse', '_Pattern__parse_tree', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', 'inspect', 'visit', 'walk']
>>> p.inspect()
pattern_data(comparisons={'file': [(['hashes', 'SHA-256'], '=', "'aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f'")]}, observation_ops=set(), qualifiers=set())
```

Is now equivalent to:

```
>>> from stix2patterns.v21.pattern import Pattern
>>> p = Pattern("[file:hashes.'SHA-256' = 'aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f']")
>>> dir(p)
['_Pattern__do_parse', '_Pattern__parse_tree', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', 'inspect', 'visit', 'walk']
>>> p.inspect()
pattern_data(comparisons={'file': [(['hashes', 'SHA-256'], '=', "'aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f'")]}, observation_ops=set(), qualifiers=set())
```